### PR TITLE
Confusion noise sensitivity curve change

### DIFF
--- a/docs/notebooks/Derivations.ipynb
+++ b/docs/notebooks/Derivations.ipynb
@@ -797,9 +797,13 @@
    "metadata": {},
    "source": [
     "\\begin{equation}\n",
-    "S_{c}(f)=A f^{-7 / 3} e^{-f^{\\alpha}+\\beta f \\sin (\\kappa f)}\\left[1+\\tanh \\left(\\gamma\\left(f_{k}-f\\right)\\right)\\right] \\mathrm{Hz}^{-1}\n",
+    "S_{c}(f)=\\frac{A}{2} f^{-7 / 3} e^{-\\left(f / f_1\\right)^{\\alpha}}\\left[1+\\tanh \\left(\\left(f_{k}-f\\right)/f_2\\right)\\right] \\mathrm{Hz}^{-1}\n",
     "\\end{equation}\n",
-    "is the galactic confusion noise (<cite data-cite=\"Robson+2019\"></cite> Eq. 14), where the amplitude $A$ is fixed as $9 \\times 10^{-45}$ and the various parameters change over time:"
+    "is the galactic confusion noise (<cite data-cite=\"Karnesis+2021\"></cite> Eq. 6), where $f_1$ and $f_{k}$ scale with the observation time as \n",
+    "\\begin{equation}\n",
+    "\\log_{10}(\\frac{f_1}{1 Hz}) = a_1\\log_{10}(\\frac{T_{obs}}{1 yr}) + b_1, \\text{ and, } \\log_{10}(\\frac{f_k}{1 Hz}) = a_k\\log_{10}(\\frac{T_{obs}}{1 yr}) + b_k.\n",
+    "\\end{equation}\n",
+    "Each of these fit parameters is given in the table below (<cite data-cite=\"Karnesis+2021\"></cite> Table II column 1)."
    ]
   },
   {
@@ -809,13 +813,15 @@
    "source": [
     "<center>\n",
     "\n",
-    "| parameter | 6 months | 1 year | 2 years | 4 years|\n",
-    "|:-:|:-:|:-:|:-:|:-:|\n",
-    "|$\\alpha$ | 0.133 | 0.171 | 0.165 | 0.138 |\n",
-    "|$\\beta$ | 243 | 292 | 299 | -221 |\n",
-    "|$\\kappa$ | 482 | 1020 | 611 | 521 |\n",
-    "|$\\gamma$ | 917 | 1680 | 1340 | 1680 |\n",
-    "|$f_{k}$ | 0.00258 | 0.00215 | 0.00173 | 0.00113 |\n",
+    "| parameter | value\n",
+    "|:-:|:-:|\n",
+    "|$a_1$ | $-0.16$ |\n",
+    "|$a_k$ | $-0.34$ | \n",
+    "|$b_1$ | $-2.78$ | \n",
+    "|$b_k$ | $-2.53$ | \n",
+    "|$A$ | $1.15 \\times 10^{-44}$ | \n",
+    "|$f_2$ | $0.00059$ |  \n",
+    "|$\\alpha$ | $1.66$ | \n",
     "</center>"
    ]
   },

--- a/docs/notebooks/Source.ipynb
+++ b/docs/notebooks/Source.ipynb
@@ -102,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +114,7 @@
     "                            \"t_obs\": 4 * u.yr,\n",
     "                            \"L\": 2.5e9 * u.m,\n",
     "                            \"approximate_R\": False,\n",
-    "                            \"confusion_noise\": 'robson19'\n",
+    "                            \"confusion_noise\": 'karnesis21'\n",
     "                        })"
    ]
   },

--- a/docs/notebooks/refs.bib
+++ b/docs/notebooks/refs.bib
@@ -244,3 +244,22 @@ archivePrefix = {arXiv},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{Karnesis+2021,
+       author = {{Karnesis}, Nikolaos and {Babak}, Stanislav and {Pieroni}, Mauro and {Cornish}, Neil and {Littenberg}, Tyson},
+        title = "{Characterization of the stochastic signal originating from compact binary populations as measured by LISA}",
+      journal = {\prd},
+     keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Astrophysics of Galaxies, General Relativity and Quantum Cosmology},
+         year = 2021,
+        month = aug,
+       volume = {104},
+       number = {4},
+          eid = {043019},
+        pages = {043019},
+          doi = {10.1103/PhysRevD.104.043019},
+archivePrefix = {arXiv},
+       eprint = {2103.14598},
+ primaryClass = {astro-ph.IM},
+       adsurl = {https://ui.adsabs.harvard.edu/abs/2021PhRvD.104d3019K},
+      adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+

--- a/legwork/psd.py
+++ b/legwork/psd.py
@@ -69,7 +69,7 @@ def approximate_response_function(f, fstar):
     return (3 / 10) / (1 + 0.6 * (f / fstar)**2)
 
 
-def lisa_psd(f, t_obs=4 * u.yr, L=2.5e9 * u.m, approximate_R=False, confusion_noise="robson19"):
+def lisa_psd(f, t_obs=4 * u.yr, L=2.5e9 * u.m, approximate_R=False, confusion_noise="karnesis21"):
     """Calculates the effective LISA power spectral density sensitivity curve
 
     Using equations from Robson+19, calculate the effective LISA power spectral
@@ -220,7 +220,7 @@ def power_spectral_density(f, instrument="LISA", custom_psd=None, t_obs="auto", 
     confusion_noise : `various`
         Galactic confusion noise. Acceptable inputs are either one of the values listed in
         :meth:`legwork.psd.get_confusion_noise`, "auto" (automatically selects confusion noise based on
-        `instrument` - 'robson19' if LISA and 'huang20' if TianQin), or a custom function that gives the
+        `instrument` - 'karnesis21' if LISA and 'huang20' if TianQin), or a custom function that gives the
         confusion noise at each frequency for a given mission length where it would be called by running
         `noise(f, t_obs)` and return a value with units of inverse Hertz
 
@@ -232,7 +232,7 @@ def power_spectral_density(f, instrument="LISA", custom_psd=None, t_obs="auto", 
     if instrument == "LISA":
         # update any auto values to be instrument specific
         L = 2.5e9 * u.m if L == "auto" else L
-        confusion_noise = "robson19" if confusion_noise == "auto" else confusion_noise
+        confusion_noise = "karnesis21" if confusion_noise == "auto" else confusion_noise
         t_obs = 4 * u.yr if t_obs == "auto" else t_obs
 
         # calculate psd
@@ -369,6 +369,42 @@ def get_confusion_noise_thiele21(f):
     return confusion_noise * u.Hz**(-1)
 
 
+def get_confusion_noise_karnesis21(f, t_obs=4 * u.yr):
+    """Calculate the confusion noise using the model from Karnesis+21 Eqs. 6,7 and Table II.
+    Note: This fit only applies to LISA and only when the mission length is 4 years.
+
+    Parameters
+    ----------
+    f : `float/array`
+        Frequencies at which to calculate the confusion noise, must have units of frequency
+    t_obs : `float`, optional
+        Mission length, parameters are defined via a fit valid up to 10 years. By default 4 years.
+
+    Returns
+    -------
+    confusion_noise : `float/array`
+        The confusion noise at each frequency
+    """
+    # erase the units for speed
+    f = f.to(u.Hz).value
+    t_obs = t_obs.to(u.yr).value 
+
+    # parameters from Karnesis+ 2021 Table II
+    a1 = -0.61 
+    ak = -0.34 
+    b1 = -2.78 
+    bk = -2.53 
+    A = 1.55e-44 
+    f2 = 0.00059
+    alpha = 1.66 
+
+    f1 = t_obs**a1 * 10**b1 #Eq 7
+    fk = t_obs**ak * 10**bk
+
+    confusion_noise = A/2 * f**(-7 / 3.) * np.exp(-(f/f1)**alpha) * (1 + np.tanh((fk - f)/f2)) * u.Hz**(-1)
+    return confusion_noise
+
+
 def get_confusion_noise(f, model, t_obs="auto"):
     """Calculate the confusion noise for a particular model
 
@@ -377,9 +413,9 @@ def get_confusion_noise(f, model, t_obs="auto"):
     f : `float/array`
         Frequencies at which to calculate the confusion noise, must have units of frequency
     model : str, optional
-        Which model to use for the confusion noise. Must be one of 'robson19', 'huang20', 'thiele21' or None.
+        Which model to use for the confusion noise. Must be one of 'robson19', 'huang20', 'thiele21', 'karnesis21' or None.
     t_obs : `float`, optional
-        Mission length. Default is 4 years for robson19 and thiele21 and 5 years for huang20.
+        Mission length. Default is 4 years for robson19, thiele21 and karnesis21 and 5 years for huang20.
 
     Returns
     -------
@@ -403,6 +439,9 @@ def get_confusion_noise(f, model, t_obs="auto"):
         else:
             error = "Invalid mission length: Thiele+21 confusion noise is only fit for `t_obs=4*u.yr`"
             raise ValueError(error)
+    elif model == "karnesis21":
+        t_obs = 4 * u.yr if t_obs == "auto" else t_obs
+        return get_confusion_noise_karnesis21(f=f, t_obs=t_obs)
     elif model is None:
         f = f.to(u.Hz).value
         return np.zeros_like(f) * u.Hz**(-1) if isinstance(f, (list, np.ndarray)) else 0.0 * u.Hz**(-1)

--- a/legwork/source.py
+++ b/legwork/source.py
@@ -537,7 +537,7 @@ class Source():
         confusion_noise : `various`
             Galactic confusion noise. Acceptable inputs are either one of the values listed in
             :meth:`legwork.psd.get_confusion_noise`, "auto" (automatically selects confusion noise based on
-            `instrument` - 'robson19' if LISA and 'huang20' if TianQin), or a custom function that gives the
+            `instrument` - 'karnesis21' if LISA and 'huang20' if TianQin), or a custom function that gives the
             confusion noise at each frequency for a given mission length where it would be called by running
             `noise(f, t_obs)` and return a value with units of inverse Hertz
 
@@ -670,7 +670,7 @@ class Source():
         confusion_noise : `various`
             Galactic confusion noise. Acceptable inputs are either one of the values listed in
             :meth:`legwork.psd.get_confusion_noise`, "auto" (automatically selects confusion noise based on
-            `instrument` - 'robson19' if LISA and 'huang20' if TianQin), or a custom function that gives the
+            `instrument` - 'karnesis21' if LISA and 'huang20' if TianQin), or a custom function that gives the
             confusion noise at each frequency for a given mission length where it would be called by running
             `noise(f, t_obs)` and return a value with units of inverse Hertz
 
@@ -822,7 +822,7 @@ class Source():
         confusion_noise : `various`
             Galactic confusion noise. Acceptable inputs are either one of the values listed in
             :meth:`legwork.psd.get_confusion_noise`, "auto" (automatically selects confusion noise based on
-            `instrument` - 'robson19' if LISA and 'huang20' if TianQin), or a custom function that gives the
+            `instrument` - 'karnesis21' if LISA and 'huang20' if TianQin), or a custom function that gives the
             confusion noise at each frequency for a given mission length where it would be called by running
             `noise(f, t_obs)` and return a value with units of inverse Hertz
 

--- a/legwork/tests/test_psd.py
+++ b/legwork/tests/test_psd.py
@@ -20,7 +20,7 @@ class Test(unittest.TestCase):
         """check that confusion noise is doing logical things"""
         frequencies = np.logspace(-6, 0, 10000) * u.Hz
 
-        models = ["robson19", "huang20", "thiele21"]
+        models = ["robson19", "huang20", "thiele21", "karnesis21"]
         instruments = ["LISA", "TianQin", "LISA"]
         for model, instrument in zip(models, instruments):
             confused = psd.get_confusion_noise(frequencies, model=model)

--- a/legwork/visualisation.py
+++ b/legwork/visualisation.py
@@ -416,7 +416,7 @@ def plot_sources_on_sc(f_dom, snr, weights=None, snr_cutoff=0, t_obs="auto",
     confusion_noise : `various`
         Galactic confusion noise. Acceptable inputs are either one of the values listed in
         :meth:`legwork.psd.get_confusion_noise`, "auto" (automatically selects confusion noise based on
-        `instrument` - 'robson19' if LISA and 'huang20' if TianQin), or a custom function that gives the
+        `instrument` - 'karnesis21' if LISA and 'huang20' if TianQin), or a custom function that gives the
         confusion noise at each frequency for a given mission length where it would be called by running
         `noise(f, t_obs)` and return a value with units of inverse Hertz
 


### PR DESCRIPTION
As suggested in #125, implemented the [Karnesis confusion noise](https://link.aps.org/accepted/10.1103/PhysRevD.104.043019 )in psd.py; changed this to default in all functions calling the LISA psd instead of Robson+19. Changed the documentation accordingly.

Wasn't sure what column of Table II to use (the exact confusion noise depends a bit on the iterative subtraction / smoothing scheme employed), but all give very similar curves. 

